### PR TITLE
Change delete settings for usability

### DIFF
--- a/Packages/net.gatosyocora.meshdeleterwithtexture/Editor/Scripts/MeshDeleter.cs
+++ b/Packages/net.gatosyocora.meshdeleterwithtexture/Editor/Scripts/MeshDeleter.cs
@@ -84,35 +84,35 @@ namespace Gatosyocora.MeshDeleterWithTexture
             {
                 throw new ArgumentException("isDeletePositions and (textureSize.x * textureSize.y) are not same size");
             }
-        
+
             var deleteIndexList = new SortedSet<int>();
-        
+
             for (int i = 0; i < uvs.Count(); i++)
             {
                 var u = uvs[i].x < 0 ? 1f - Mathf.Abs(uvs[i].x % 1.0f) : uvs[i].x % 1.0f;
                 var v = uvs[i].y < 0 ? 1f - Mathf.Abs(uvs[i].y % 1.0f) : uvs[i].y % 1.0f;
-        
+
                 var x = (int)(u * textureSize.x);
                 var y = (int)(v * textureSize.y);
-        
+
                 if (x == textureSize.x || y == textureSize.y) continue;
-        
+
                 int index = y * textureSize.x + x;
-        
+
                 if (isDeletePositions[index])
                 {
                     deleteIndexList.Add(i);
                 }
             }
-        
+
             var preservedIndexList = new SortedSet<int>();
-        
+
             for (int i = 0; i < triangles.Length; i += 3)
             {
                 var t0 = triangles[i];
                 var t1 = triangles[i + 1];
                 var t2 = triangles[i + 2];
-        
+
                 // if any of the vertices are not in the delete list, preserve the triangle's vertices
                 // 削除リストにない頂点がある場合、その三角形の頂点を保持します
                 if (!deleteIndexList.Contains(t0) ||
@@ -124,14 +124,14 @@ namespace Gatosyocora.MeshDeleterWithTexture
                     preservedIndexList.Add(t2);
                 }
             }
-        
+
             // Remove the preserved indices from the delete list
             // 保存されたindexを削除リストから削除します
             foreach (var index in preservedIndexList)
             {
                 deleteIndexList.Remove(index);
             }
-        
+
             return deleteIndexList.ToList();
         }
 

--- a/Packages/net.gatosyocora.meshdeleterwithtexture/Editor/Scripts/MeshDeleter.cs
+++ b/Packages/net.gatosyocora.meshdeleterwithtexture/Editor/Scripts/MeshDeleter.cs
@@ -14,7 +14,7 @@ namespace Gatosyocora.MeshDeleterWithTexture
         public static (Mesh, bool[]) RemoveTriangles(Mesh mesh, bool[] deletePos, Vector2Int textureSize, List<int> materialIndexList, bool showProgressBar = true)
         {
             // 削除する頂点のリストを取得
-            var deleteIndexList = GetDeleteVertexIndices(mesh.uv.ToList(), deletePos, textureSize);
+            var deleteIndexList = GetDeleteVertexIndices(mesh.uv.ToList(), mesh.triangles, deletePos, textureSize);
 
             if (!deleteIndexList.Any())
             {
@@ -74,37 +74,65 @@ namespace Gatosyocora.MeshDeleterWithTexture
         /// 削除する頂点のIndexのListを取得する
         /// </summary>
         /// <param name="uvs">各頂点のUV座標</param>
-        /// <param name="deletePos">削除するかどうか(テクスチャの幅×高さのサイズ)</param>
+        /// <param name="triangles">三角形インデックス配列</param>
+        /// <param name="isDeletePositions">削除するかどうか(テクスチャの幅×高さのサイズ)</param>
         /// <param name="textureSize">テクスチャのサイズ</param>
         /// <returns>削除する頂点のindexのList</returns>
-        private static List<int> GetDeleteVertexIndices(List<Vector2> uvs, bool[] isDeletePositions, Vector2Int textureSize)
+        private static List<int> GetDeleteVertexIndices(List<Vector2> uvs, int[] triangles, bool[] isDeletePositions, Vector2Int textureSize)
         {
             if (isDeletePositions.Length != textureSize.x * textureSize.y)
             {
                 throw new ArgumentException("isDeletePositions and (textureSize.x * textureSize.y) are not same size");
             }
-
-            var deleteIndexList = new List<int>();
-
+        
+            var deleteIndexList = new SortedSet<int>();
+        
             for (int i = 0; i < uvs.Count(); i++)
             {
                 var u = uvs[i].x < 0 ? 1f - Mathf.Abs(uvs[i].x % 1.0f) : uvs[i].x % 1.0f;
                 var v = uvs[i].y < 0 ? 1f - Mathf.Abs(uvs[i].y % 1.0f) : uvs[i].y % 1.0f;
-
+        
                 var x = (int)(u * textureSize.x);
                 var y = (int)(v * textureSize.y);
-
+        
                 if (x == textureSize.x || y == textureSize.y) continue;
-
+        
                 int index = y * textureSize.x + x;
-
+        
                 if (isDeletePositions[index])
                 {
                     deleteIndexList.Add(i);
                 }
             }
-
-            return deleteIndexList;
+        
+            var preservedIndexList = new SortedSet<int>();
+        
+            for (int i = 0; i < triangles.Length; i += 3)
+            {
+                var t0 = triangles[i];
+                var t1 = triangles[i + 1];
+                var t2 = triangles[i + 2];
+        
+                // if any of the vertices are not in the delete list, preserve the triangle's vertices
+                // 削除リストにない頂点がある場合、その三角形の頂点を保持します
+                if (!deleteIndexList.Contains(t0) ||
+                    !deleteIndexList.Contains(t1) ||
+                    !deleteIndexList.Contains(t2))
+                {
+                    preservedIndexList.Add(t0);
+                    preservedIndexList.Add(t1);
+                    preservedIndexList.Add(t2);
+                }
+            }
+        
+            // Remove the preserved indices from the delete list
+            // 保存されたindexを削除リストから削除します
+            foreach (var index in preservedIndexList)
+            {
+                deleteIndexList.Remove(index);
+            }
+        
+            return deleteIndexList.ToList();
         }
 
         /// <summary>


### PR DESCRIPTION
Preserve triangles that have not had all 3 of their vertices covered by the delete texture for usability. Makes deleting the mesh under clothes very simple and easy.